### PR TITLE
Harden deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,18 +5,22 @@ on:
     branches:
       - master
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     permissions:
-        packages: write
+        contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: rsync deployments
-        uses: burnett01/rsync-deployments@v9
+        uses: burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5 # v9
         with:
-          switches: -avzr --delete --exclude .git --exclude .github --exclude .gitignore
+          switches: -avz --delete --exclude .git --exclude .github --exclude .gitignore
           path: ./
           remote_path: ${{ vars.REMOTE_RSYNC_PATH }}
           remote_host: ${{ secrets.REMOTE_SSH_HOST }}


### PR DESCRIPTION
Security and correctness hardening for `.github/workflows/deploy.yml`. No change to what the deploy does.

## Changes
- **Drop unused `packages: write`** → request minimal `contents: read`. The job only rsyncs over SSH; it never touches GitHub Packages.
- **Pin `burnett01/rsync-deployments` to a commit SHA** (`4d419d1`, v9). This action receives `SSH_PRIVATE_KEY`, so a moved tag could otherwise swap the code that handles the deploy key.
- **Add a `concurrency` group** so two pushes to `master` can't run overlapping `rsync --delete` deploys against the same remote path. `cancel-in-progress: false` lets an in-flight deploy finish rather than being killed mid-sync.
- **Remove redundant `-r`** from rsync switches (`-a` already implies recursive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)